### PR TITLE
Add 3D graphics to drift game

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# drift-game
+# Drift Game
+
+A simple 3D car drifting demo built with [Three.js](https://threejs.org/).
+
+## How to Play
+
+1. Open `index.html` in a modern web browser.
+2. Use the arrow keys to drive the car:
+   - Up Arrow: Accelerate
+   - Down Arrow: Brake/Reverse
+   - Left/Right Arrow: Steer
+
+The car will drift as you steer at speed. Use the arrow keys to control it.
+
+## Development
+
+All game logic is contained in `src/script.js`. Styles are defined in
+`style.css`.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Drift Game</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <canvas id="gameCanvas"></canvas>
+    <script src="https://unpkg.com/three@0.160.1/build/three.min.js"></script>
+    <script src="src/script.js"></script>
+</body>
+</html>

--- a/src/script.js
+++ b/src/script.js
@@ -1,0 +1,121 @@
+const canvas = document.getElementById('gameCanvas');
+const renderer = new THREE.WebGLRenderer({ canvas });
+renderer.setSize(window.innerWidth, window.innerHeight);
+
+const scene = new THREE.Scene();
+scene.background = new THREE.Color(0x202020);
+
+const camera = new THREE.PerspectiveCamera(
+  75,
+  window.innerWidth / window.innerHeight,
+  0.1,
+  1000
+);
+
+const ambient = new THREE.HemisphereLight(0xffffff, 0x444444, 1);
+scene.add(ambient);
+const dirLight = new THREE.DirectionalLight(0xffffff, 0.5);
+dirLight.position.set(5, 10, 7.5);
+scene.add(dirLight);
+
+const groundGeo = new THREE.PlaneGeometry(200, 200);
+const groundMat = new THREE.MeshStandardMaterial({ color: 0x555555 });
+const ground = new THREE.Mesh(groundGeo, groundMat);
+ground.rotation.x = -Math.PI / 2;
+scene.add(ground);
+
+const carGeo = new THREE.BoxGeometry(1, 0.5, 2);
+const carMat = new THREE.MeshStandardMaterial({ color: 0xff0000 });
+const carMesh = new THREE.Mesh(carGeo, carMat);
+carMesh.position.y = 0.25;
+scene.add(carMesh);
+
+class Car {
+  constructor(mesh) {
+    this.mesh = mesh;
+    this.x = 0;
+    this.z = 0;
+    this.angle = 0;
+    this.speed = 0;
+    this.vx = 0;
+    this.vz = 0;
+  }
+
+  update(input, dt) {
+    const accel = 10;
+    const maxSpeed = 20;
+    const friction = 0.98;
+    const drift = 0.92;
+    const turnSpeed = 2;
+
+    if (input.up) this.speed += accel * dt;
+    if (input.down) this.speed -= accel * dt;
+    this.speed = Math.max(-maxSpeed, Math.min(maxSpeed, this.speed));
+
+    if (input.left) this.angle += turnSpeed * dt * (this.vx !== 0 || this.vz !== 0 ? 1 : 0);
+    if (input.right) this.angle -= turnSpeed * dt * (this.vx !== 0 || this.vz !== 0 ? 1 : 0);
+
+    const forwardX = Math.sin(this.angle);
+    const forwardZ = Math.cos(this.angle);
+    this.vx += forwardX * this.speed * dt;
+    this.vz += forwardZ * this.speed * dt;
+    this.speed = 0;
+
+    this.vx *= friction;
+    this.vz *= friction;
+
+    const rightX = forwardZ;
+    const rightZ = -forwardX;
+    const sideSpeed = this.vx * rightX + this.vz * rightZ;
+    this.vx -= sideSpeed * (1 - drift) * rightX;
+    this.vz -= sideSpeed * (1 - drift) * rightZ;
+
+    this.x += this.vx * dt;
+    this.z += this.vz * dt;
+
+    this.mesh.position.set(this.x, 0.25, this.z);
+    this.mesh.rotation.y = -this.angle;
+  }
+}
+
+const input = { up: false, down: false, left: false, right: false };
+window.addEventListener('keydown', (e) => {
+  if (e.key === 'ArrowUp') input.up = true;
+  if (e.key === 'ArrowDown') input.down = true;
+  if (e.key === 'ArrowLeft') input.left = true;
+  if (e.key === 'ArrowRight') input.right = true;
+});
+window.addEventListener('keyup', (e) => {
+  if (e.key === 'ArrowUp') input.up = false;
+  if (e.key === 'ArrowDown') input.down = false;
+  if (e.key === 'ArrowLeft') input.left = false;
+  if (e.key === 'ArrowRight') input.right = false;
+});
+
+const car = new Car(carMesh);
+
+function resize() {
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+}
+window.addEventListener('resize', resize);
+
+let lastTime = performance.now();
+function gameLoop(time) {
+  const dt = (time - lastTime) / 1000;
+  lastTime = time;
+
+  car.update(input, dt);
+
+  const camDistance = 5;
+  const camHeight = 3;
+  camera.position.x = car.x - Math.sin(car.angle) * camDistance;
+  camera.position.y = camHeight;
+  camera.position.z = car.z - Math.cos(car.angle) * camDistance;
+  camera.lookAt(car.x, 0.25, car.z);
+
+  renderer.render(scene, camera);
+  requestAnimationFrame(gameLoop);
+}
+requestAnimationFrame(gameLoop);

--- a/style.css
+++ b/style.css
@@ -1,0 +1,13 @@
+body {
+    margin: 0;
+    overflow: hidden;
+    background-color: #000;
+    color: white;
+    font-family: Arial, sans-serif;
+}
+
+canvas {
+    width: 100%;
+    height: 100%;
+    display: block;
+}


### PR DESCRIPTION
## Summary
- switch layout and styles for fullscreen WebGL canvas
- load three.js and render basic 3D scene
- rewrite game logic to use 3D car and camera
- update README with 3D details

## Testing
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_6841e6592870833390db77d863a70d8b